### PR TITLE
Fix missing pydantic compat

### DIFF
--- a/sdk-py/mmopdca_sdk/pydantic_compat.py
+++ b/sdk-py/mmopdca_sdk/pydantic_compat.py
@@ -1,0 +1,7 @@
+try:
+    from pydantic import field_validator, ConfigDict
+except ImportError:  # pragma: no cover - pydantic<2
+    from pydantic import validator as field_validator  # type: ignore
+    ConfigDict = dict  # type: ignore
+
+__all__ = ['field_validator', 'ConfigDict']


### PR DESCRIPTION
## Summary
- include `pydantic_compat` inside `mmopdca_sdk`

## Testing
- `pytest -q`