### PR TITLE
Fix README instructions for Prometheus port

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,4 @@ set `HOST_PROM_PORT` accordingly:
 export HOST_PROM_PORT=19090
 docker compose up -d
 ```
-```
 If you see an error like 'Bind for 0.0.0.0:9090 failed: port is already allocated' when starting Prometheus, choose an unused port for HOST_PROM_PORT and rerun the compose command.


### PR DESCRIPTION
## Summary
- fix README formatting and instructions about PROM port

## Testing
- `pytest -q` *(fails: 23 errors during collection)*