### PR TITLE
Fix CI port conflict for Prometheus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       HOST_POSTGRES_PORT: '15432'
       HOST_REDIS_PORT: '16379'
-      HOST_PROM_PORT: '9090'
+      HOST_PROM_PORT: '19090'
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -72,5 +72,4 @@ set `HOST_PROM_PORT` accordingly:
 export HOST_PROM_PORT=19090
 docker compose up -d
 ```
-```
 If you see an error like 'Bind for 0.0.0.0:9090 failed: port is already allocated' when starting Prometheus, choose an unused port for HOST_PROM_PORT and rerun the compose command.


### PR DESCRIPTION
## Notes
- set HOST_PROM_PORT to 19090 in CI to avoid port allocation issues
- clean up README instructions about changing Prometheus port

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mmopdca_sdk.pydantic_compat')*