### PR TITLE
Fix missing pydantic compat module

### DIFF
--- a/sdk-py/mmopdca_sdk/pydantic_compat.py
+++ b/sdk-py/mmopdca_sdk/pydantic_compat.py
@@ -1,0 +1,11 @@
+import pydantic
+
+if pydantic.VERSION.startswith("1"):
+    # pydantic v1 compatibility
+    def ConfigDict(**kwargs):
+        return dict(**kwargs)
+    from pydantic import validator as field_validator  # type: ignore
+else:  # pragma: no cover - pydantic v2
+    from pydantic import ConfigDict, field_validator
+
+__all__ = ["ConfigDict", "field_validator"]


### PR DESCRIPTION
## Summary
- add missing `pydantic_compat` to the Python SDK

## Testing
- `pytest -q sdk-py/test/test_act_action.py`
