### PR TITLE
Fix Prometheus port collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       HOST_POSTGRES_PORT: '15432'
       HOST_REDIS_PORT: '16379'
-      HOST_PROM_PORT: '9090'
+      HOST_PROM_PORT: '19090'
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +34,7 @@ jobs:
         ports: ['5432:5432']
       prom:
         image: prom/prometheus:v2.52.0
-        ports: ['9090:9090']
+        ports: ['19090:9090']
       grafana:
         image: grafana/grafana-oss:10.4.2
         ports: ['3000:3000']

--- a/.github/workflows/stack-health.yml
+++ b/.github/workflows/stack-health.yml
@@ -49,7 +49,7 @@ jobs:
           set -eu
           for i in {1..30}; do
             curl -fs http://localhost:8001/docs \
-              && curl -fs http://localhost:9090/ \
+              && curl -fs http://localhost:19090/ \
               && curl -fs http://localhost:9121/metrics \
               && curl -fs http://localhost:9808/metrics \
               && echo "All endpoints are healthy!" \

--- a/README.md
+++ b/README.md
@@ -65,12 +65,11 @@ export HOST_POSTGRES_PORT=15432
 docker compose up -d
 ```
 
-Prometheus exposes port `9090` on the host. If the port is taken,
+Prometheus exposes port `19090` on the host by default. If the port is taken,
 set `HOST_PROM_PORT` accordingly:
 
 ```bash
 export HOST_PROM_PORT=19090
 docker compose up -d
 ```
-```
-If you see an error like 'Bind for 0.0.0.0:9090 failed: port is already allocated' when starting Prometheus, choose an unused port for HOST_PROM_PORT and rerun the compose command.
+If you see an error like 'Bind for 0.0.0.0:19090 failed: port is already allocated' when starting Prometheus, choose an unused port for HOST_PROM_PORT and rerun the compose command.

--- a/docker/compose.ci.yml
+++ b/docker/compose.ci.yml
@@ -94,6 +94,6 @@ services:
       - redis-exporter
       - celery-exporter
     ports:
-      - "${HOST_PROM_PORT:-9090}:9090"
+      - "${HOST_PROM_PORT:-19090}:9090"
 
 volumes: {}

--- a/docker/compose.core.yml
+++ b/docker/compose.core.yml
@@ -190,7 +190,7 @@ services:
       celery-exporter:
         condition: service_started
     ports:
-      - "${HOST_PROM_PORT:-9090}:9090"
+      - "${HOST_PROM_PORT:-19090}:9090"
     networks:
       - mmopdca_default
     restart: unless-stopped

--- a/docker/compose.ports.yml
+++ b/docker/compose.ports.yml
@@ -13,7 +13,7 @@ services:
 
   prom:
     ports:
-      - "${HOST_PROM_PORT:-9090}:9090"
+      - "${HOST_PROM_PORT:-19090}:9090"
 
   grafana:
     ports:

--- a/docker/compose.prom.yml
+++ b/docker/compose.prom.yml
@@ -1,4 +1,4 @@
 services:
   prom:
     ports:
-      - "${HOST_PROM_PORT:-9090}:9090"
+      - "${HOST_PROM_PORT:-19090}:9090"

--- a/scripts/ci-up.ps1
+++ b/scripts/ci-up.ps1
@@ -41,9 +41,10 @@ Write-Host "`n📦 Containers status:"
 docker compose --env-file $EnvFile -f $ComposeFile ps
 
 # 6) HTTP エンドポイント疎通チェック
+$hostPromPort = ${Env:HOST_PROM_PORT} ? ${Env:HOST_PROM_PORT} : 19090
 $urls = @(
   "http://localhost:8001/docs",
-  "http://localhost:9090/-/ready",
+  "http://localhost:$hostPromPort/-/ready",
   "http://localhost:9121/metrics",
   "http://localhost:9808/metrics"
 )


### PR DESCRIPTION
## Summary
- bump the host port for Prometheus to 19090
- update CI and helper scripts for new port

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mmopdca_sdk.pydantic_compat')*