### PR TITLE
Fix test flow and compatibility

### DIFF
--- a/api/routers/check_api.py
+++ b/api/routers/check_api.py
@@ -72,13 +72,6 @@ def enqueue_check(do_id: str) -> JSONResponse:
     task_id = uuid.uuid4().hex
     check_id = f"check-{task_id[:8]}"
 
-    # Celery に enqueue (文字列タスク名)
-    celery_app.send_task(
-        "core.tasks.check_tasks.run_check_task",
-        args=[check_id, do_id],
-        task_id=task_id,
-    )
-
     # 初期レコード作成
     rec: Dict[str, Any] = {
         "id": check_id,
@@ -89,6 +82,13 @@ def enqueue_check(do_id: str) -> JSONResponse:
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     _upsert(rec)
+
+    # Celery に enqueue (文字列タスク名)
+    celery_app.send_task(
+        "core.tasks.check_tasks.run_check_task",
+        args=[check_id, do_id],
+        task_id=task_id,
+    )
 
     return JSONResponse(
         status_code=status.HTTP_202_ACCEPTED,

--- a/core/schemas/artifact_schemas.py
+++ b/core/schemas/artifact_schemas.py
@@ -42,8 +42,12 @@ class PredictionArtifact(BaseModel):
     # ------------------------------------------------------------------
     def model_dump_json(self, **kwargs) -> str:
         """Return JSON representation (pydantic v1 compat)."""
-        return super().model_dump_json(**kwargs)
+        if hasattr(super(), "model_dump_json"):
+            return super().model_dump_json(**kwargs)
+        return self.json(**kwargs)
 
     @classmethod
     def model_validate_json(cls, data: str, **kwargs) -> "PredictionArtifact":
-        return super().model_validate_json(data, **kwargs)
+        if hasattr(super(), "model_validate_json"):
+            return super().model_validate_json(data, **kwargs)
+        return cls.parse_raw(data, **kwargs)

--- a/core/schemas/meta_schemas.py
+++ b/core/schemas/meta_schemas.py
@@ -66,6 +66,8 @@ class MetaInfo(BaseModel):
     # Compatibility helpers for pydantic v1
     # ------------------------------------------------------------------
     def model_dump(self, *, mode: str = "python", **kwargs):  # type: ignore[override]
+        if hasattr(super(), "model_dump"):
+            return super().model_dump(mode=mode, **kwargs)
         if mode == "json":
             import json
             return json.loads(self.json(**kwargs))
@@ -73,8 +75,11 @@ class MetaInfo(BaseModel):
 
     @classmethod
     def model_validate(cls, data, **kwargs):  # type: ignore[override]
-        return super().model_validate(data, **kwargs)
+        if hasattr(super(), "model_validate"):
+            return super().model_validate(data, **kwargs)
+        return cls.parse_obj(data)
 
 
 # 公開シンボル
 __all__ = ["MetricSpec", "MetaInfo"]
+

--- a/core/schemas/plan_schemas.py
+++ b/core/schemas/plan_schemas.py
@@ -39,13 +39,7 @@ class PlanResponse(BaseModel):
     # DSL フィールドもそのまま保持
     model_config = ConfigDict(extra="allow")
 
-    def dict(self, *args, **kwargs):  # pragma: no cover - pydantic v1 compatibility
-        data = super().dict(*args, **kwargs)
-        extras = {k: v for k, v in self.__dict__.items() if k not in data}
-        data.update(extras)
-        return data
-
-    def json(self, *args, **kwargs):  # pragma: no cover - pydantic v1 compatibility
-        return json.dumps(self.dict(*args, **kwargs))
+    class Config:  # type: ignore[too-many-ancestors]
+        extra = "allow"
 
 __all__ = ["PlanCreateRequest", "PlanResponse"]

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -22,6 +22,8 @@ def _request(method, url, *, data=None, json=None, timeout=None, headers=None):
     else:
         headers_dict = {}
     hdrs = {**(headers or {}), **headers_dict}
+    if isinstance(data, str):
+        data = data.encode()
     req = urllib.request.Request(url, data=data, method=method, headers=hdrs)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:

--- a/sdk-py/mmopdca_sdk/pydantic_compat.py
+++ b/sdk-py/mmopdca_sdk/pydantic_compat.py
@@ -1,0 +1,2 @@
+from .pydantic_shim import *  # noqa: F401,F403
+

--- a/sdk-py/mmopdca_sdk/pydantic_shim.py
+++ b/sdk-py/mmopdca_sdk/pydantic_shim.py
@@ -3,7 +3,18 @@ try:
 except ImportError:  # pragma: no cover - for pydantic v1
     from pydantic import validate_arguments as validate_call  # type: ignore
 
-from pydantic import Field, StrictFloat, StrictStr, StrictInt, StrictBytes
+from pydantic import (
+    Field,
+    StrictFloat,
+    StrictStr,
+    StrictInt,
+    StrictBytes,
+)
+try:
+    from pydantic import ConfigDict, field_validator
+except ImportError:  # pragma: no cover - for pydantic v1
+    ConfigDict = dict  # type: ignore
+    from pydantic.class_validators import validator as field_validator  # type: ignore
 
 __all__ = [
     "validate_call",
@@ -12,4 +23,6 @@ __all__ = [
     "StrictStr",
     "StrictInt",
     "StrictBytes",
+    "ConfigDict",
+    "field_validator",
 ]


### PR DESCRIPTION
## Summary
- ensure check record is created before Celery call
- emulate requests data encoding
- add pydantic v1 compatibility shims
- fix PlanResponse extras under pydantic v1
- support legacy methods for artifacts and meta schemas

## Testing
- `pytest -q`