### PR TITLE
Fix pydantic error in tests

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,3 +5,4 @@ fastapi>=0.111,<0.117
 uvicorn[standard]>=0.29,<0.32
 fastjsonschema>=2.19
 httpx>=0.27
+pydantic>=2,<3


### PR DESCRIPTION
## Summary
- ensure CI installs pydantic v2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pip install -r requirements-ci.txt` *(fails: no network access)*