### PR TITLE
Fix pydantic config error

### DIFF
--- a/core/schemas/plan_schemas.py
+++ b/core/schemas/plan_schemas.py
@@ -9,7 +9,7 @@ from datetime import date
 from typing import Optional
 
 import json
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field
 
 
 # POST /plan/ 用 --------------------------------------------------------
@@ -37,7 +37,8 @@ class PlanResponse(BaseModel):
     created_at: str
 
     # DSL フィールドもそのまま保持
-    model_config = ConfigDict(extra="allow")
+    class Config:
+        extra = "allow"
 
     def dict(self, *args, **kwargs):  # pragma: no cover - pydantic v1 compatibility
         data = super().dict(*args, **kwargs)

--- a/sdk-py/mmopdca_sdk/pydantic_compat.py
+++ b/sdk-py/mmopdca_sdk/pydantic_compat.py
@@ -1,0 +1,7 @@
+try:
+    from pydantic import field_validator, ConfigDict
+except ImportError:  # pragma: no cover - pydantic<2
+    from pydantic import validator as field_validator  # type: ignore
+    ConfigDict = dict  # type: ignore
+
+__all__ = ['field_validator', 'ConfigDict']


### PR DESCRIPTION
## Summary
- avoid `Config`/`model_config` collision in PlanResponse
- add missing `pydantic_compat` module inside sdk package

## Testing
- `pytest -q` *(fails: report generation and HTTP flow tests)*