### PR TITLE
Fix tests by improving check task flow and Pydantic v1 fallback

### DIFF
--- a/api/routers/check_api.py
+++ b/api/routers/check_api.py
@@ -72,13 +72,6 @@ def enqueue_check(do_id: str) -> JSONResponse:
     task_id = uuid.uuid4().hex
     check_id = f"check-{task_id[:8]}"
 
-    # Celery に enqueue (文字列タスク名)
-    celery_app.send_task(
-        "core.tasks.check_tasks.run_check_task",
-        args=[check_id, do_id],
-        task_id=task_id,
-    )
-
     # 初期レコード作成
     rec: Dict[str, Any] = {
         "id": check_id,
@@ -89,6 +82,13 @@ def enqueue_check(do_id: str) -> JSONResponse:
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     _upsert(rec)
+
+    # Celery に enqueue (文字列タスク名)
+    celery_app.send_task(
+        "core.tasks.check_tasks.run_check_task",
+        args=[check_id, do_id],
+        task_id=task_id,
+    )
 
     return JSONResponse(
         status_code=status.HTTP_202_ACCEPTED,

--- a/core/schemas/artifact_schemas.py
+++ b/core/schemas/artifact_schemas.py
@@ -42,8 +42,14 @@ class PredictionArtifact(BaseModel):
     # ------------------------------------------------------------------
     def model_dump_json(self, **kwargs) -> str:
         """Return JSON representation (pydantic v1 compat)."""
-        return super().model_dump_json(**kwargs)
+        try:
+            return super().model_dump_json(**kwargs)
+        except AttributeError:  # pragma: no cover - pydantic v1
+            return self.json(**kwargs)
 
     @classmethod
     def model_validate_json(cls, data: str, **kwargs) -> "PredictionArtifact":
-        return super().model_validate_json(data, **kwargs)
+        try:
+            return super().model_validate_json(data, **kwargs)
+        except AttributeError:  # pragma: no cover - pydantic v1
+            return cls.parse_raw(data, **kwargs)

--- a/core/schemas/meta_schemas.py
+++ b/core/schemas/meta_schemas.py
@@ -24,6 +24,7 @@ from datetime import date, datetime
 from typing import List
 
 from pydantic import BaseModel, Field, ConfigDict
+from pydantic import __version__ as _pyd_version
 
 
 class MetricSpec(BaseModel):
@@ -73,7 +74,9 @@ class MetaInfo(BaseModel):
 
     @classmethod
     def model_validate(cls, data, **kwargs):  # type: ignore[override]
-        return super().model_validate(data, **kwargs)
+        if not _pyd_version.startswith("1"):
+            return super().model_validate(data, **kwargs)
+        return cls.parse_obj(data)
 
 
 # 公開シンボル

--- a/core/schemas/plan_schemas.py
+++ b/core/schemas/plan_schemas.py
@@ -9,7 +9,14 @@ from datetime import date
 from typing import Optional
 
 import json
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field
+from pydantic import __version__ as _pyd_version
+try:
+    from pydantic import ConfigDict as _Cfg
+    _IS_PYDANTIC_V2 = not _pyd_version.startswith("1")
+except Exception:  # pragma: no cover - pydantic v1
+    _Cfg = None
+    _IS_PYDANTIC_V2 = False
 
 
 # POST /plan/ 用 --------------------------------------------------------
@@ -37,7 +44,11 @@ class PlanResponse(BaseModel):
     created_at: str
 
     # DSL フィールドもそのまま保持
-    model_config = ConfigDict(extra="allow")
+    if _IS_PYDANTIC_V2 and _Cfg is not None:
+        model_config = _Cfg(extra="allow")
+    else:  # pragma: no cover - pydantic v1
+        class Config:
+            extra = "allow"
 
     def dict(self, *args, **kwargs):  # pragma: no cover - pydantic v1 compatibility
         data = super().dict(*args, **kwargs)

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -21,6 +21,8 @@ def _request(method, url, *, data=None, json=None, timeout=None, headers=None):
         headers_dict = {'Content-Type': 'application/json'}
     else:
         headers_dict = {}
+    if isinstance(data, str):
+        data = data.encode()
     hdrs = {**(headers or {}), **headers_dict}
     req = urllib.request.Request(url, data=data, method=method, headers=hdrs)
     try:

--- a/sdk-py/mmopdca_sdk/pydantic_compat.py
+++ b/sdk-py/mmopdca_sdk/pydantic_compat.py
@@ -1,0 +1,8 @@
+try:
+    from pydantic import ConfigDict, field_validator
+except ImportError:  # pragma: no cover - pydantic v1 fallback
+    ConfigDict = dict  # type: ignore[misc]
+    from pydantic import validator as field_validator  # type: ignore
+
+__all__ = ["ConfigDict", "field_validator"]
+


### PR DESCRIPTION
## Summary
- ensure check creation does not overwrite completed record
- auto-encode strings in `requests` stub
- add Pydantic v1 compatibility helpers
- fix plan schema to honour extra fields on Pydantic v1
- update artifact schema helpers for Pydantic v1
- add missing `pydantic_compat` for SDK models

## Testing
- `pytest -q`