### PR TITLE
Fix tests and add pydantic compatibility

### DIFF
--- a/core/schemas/artifact_schemas.py
+++ b/core/schemas/artifact_schemas.py
@@ -42,8 +42,14 @@ class PredictionArtifact(BaseModel):
     # ------------------------------------------------------------------
     def model_dump_json(self, **kwargs) -> str:
         """Return JSON representation (pydantic v1 compat)."""
-        return super().model_dump_json(**kwargs)
+        try:
+            return super().model_dump_json(**kwargs)
+        except AttributeError:  # pragma: no cover - pydantic v1
+            return self.json(**kwargs)
 
     @classmethod
     def model_validate_json(cls, data: str, **kwargs) -> "PredictionArtifact":
-        return super().model_validate_json(data, **kwargs)
+        try:
+            return super().model_validate_json(data, **kwargs)
+        except AttributeError:  # pragma: no cover - pydantic v1
+            return cls.parse_raw(data, **kwargs)

--- a/core/schemas/check_schemas.py
+++ b/core/schemas/check_schemas.py
@@ -29,6 +29,8 @@ class CheckReport(BaseModel):
     passed: bool = Field(..., description="閾値をクリアしたら True")
 
     model_config = ConfigDict(extra="allow")  # ★ 追加指標を許容
+    class Config:  # pragma: no cover - pydantic v1 fallback
+        extra = "allow"
 
 
 class CheckResult(BaseModel):
@@ -48,3 +50,5 @@ class CheckResult(BaseModel):
     )
 
     model_config = ConfigDict(from_attributes=True)
+    class Config:  # pragma: no cover - pydantic v1 fallback
+        orm_mode = True

--- a/core/schemas/meta_schemas.py
+++ b/core/schemas/meta_schemas.py
@@ -66,14 +66,20 @@ class MetaInfo(BaseModel):
     # Compatibility helpers for pydantic v1
     # ------------------------------------------------------------------
     def model_dump(self, *, mode: str = "python", **kwargs):  # type: ignore[override]
-        if mode == "json":
-            import json
-            return json.loads(self.json(**kwargs))
-        return self.dict(**kwargs)
+        try:
+            return super().model_dump(mode=mode, **kwargs)
+        except AttributeError:  # pragma: no cover - pydantic v1
+            if mode == "json":
+                import json
+                return json.loads(self.json(**kwargs))
+            return self.dict(**kwargs)
 
     @classmethod
     def model_validate(cls, data, **kwargs):  # type: ignore[override]
-        return super().model_validate(data, **kwargs)
+        try:
+            return super().model_validate(data, **kwargs)
+        except AttributeError:  # pragma: no cover - pydantic v1
+            return cls.parse_obj(data)
 
 
 # 公開シンボル

--- a/core/schemas/plan_schemas.py
+++ b/core/schemas/plan_schemas.py
@@ -38,6 +38,8 @@ class PlanResponse(BaseModel):
 
     # DSL フィールドもそのまま保持
     model_config = ConfigDict(extra="allow")
+    class Config:  # pragma: no cover - pydantic v1 fallback
+        extra = "allow"
 
     def dict(self, *args, **kwargs):  # pragma: no cover - pydantic v1 compatibility
         data = super().dict(*args, **kwargs)

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -22,6 +22,8 @@ def _request(method, url, *, data=None, json=None, timeout=None, headers=None):
     else:
         headers_dict = {}
     hdrs = {**(headers or {}), **headers_dict}
+    if isinstance(data, str):
+        data = data.encode()
     req = urllib.request.Request(url, data=data, method=method, headers=hdrs)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:

--- a/requests_stub.py
+++ b/requests_stub.py
@@ -20,6 +20,8 @@ def _make_request(method: str, url: str, *, data=None, json_data=None):
         headers = {"Content-Type": "application/json"}
     else:
         headers = {}
+    if isinstance(data, str):
+        data = data.encode()
     req = _request.Request(url, data=data, headers=headers, method=method.upper())
     with _request.urlopen(req) as resp:
         return Response(resp.getcode(), dict(resp.headers), resp.read())

--- a/sdk-py/mmopdca_sdk/pydantic_compat.py
+++ b/sdk-py/mmopdca_sdk/pydantic_compat.py
@@ -1,0 +1,7 @@
+try:
+    from pydantic import ConfigDict, field_validator
+except ImportError:  # pragma: no cover - support pydantic v1
+    ConfigDict = dict  # type: ignore
+    from pydantic import validator as field_validator  # type: ignore
+
+__all__ = ["ConfigDict", "field_validator"]


### PR DESCRIPTION
## Summary
- add missing `pydantic_compat` module for the Python SDK
- encode string bodies in requests stubs
- make schema helpers compatible with Pydantic v1
- patch test Celery stub to update records asynchronously

## Testing
- `pytest -q`